### PR TITLE
Add backwards compatible atomicAdd for old devices

### DIFF
--- a/hera_gpu/redcal.py
+++ b/hera_gpu/redcal.py
@@ -41,6 +41,28 @@ GPU_TEMPLATE = """
 #include <pycuda-helpers.hpp>
 #include <stdio.h>
 
+// Provide atomicAdd operation for doubles for old (compute capability < 6.0) devices
+// from https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomic-functions
+#if __CUDA_ARCH__ < 600
+__device__ double atomicAdd(double* address, double val)
+{{
+    unsigned long long int* address_as_ull =
+                              (unsigned long long int*)address;
+    unsigned long long int old = *address_as_ull, assumed;
+
+    do {{
+        assumed = old;
+        old = atomicCAS(address_as_ull, assumed,
+                        __double_as_longlong(val +
+                               __longlong_as_double(assumed)));
+
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+    }} while (assumed != old);
+
+    return __longlong_as_double(old);
+}}
+#endif
+
 __device__ inline {DTYPE} mag2({CDTYPE} a) {{
     return a.x * a.x + a.y * a.y;
 }}


### PR DESCRIPTION
When attempting to run redcal on the GPUs on site, I encountered an error because our GPUs are old (compute capability = 3.5), and do not have a native `atomicAdd` operation for doubles. This provides an implementation based on the `atomicCAS` (compare-and-swap) function taken from the CUDA programming guide.